### PR TITLE
Use /sandbox/ for shell and / for /var/www

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,15 +32,26 @@ class selfpaced (
 
   include nginx
   nginx::resource::vhost { 'try.puppet.com':
-    ssl_port         => '443',
-    proxy            => 'http://127.0.0.1:3000',
-    proxy_set_header => [
-      'Upgrade $http_upgrade',
-      'Connection "Upgrade"',
-    ],
-    ssl              => true,
-    ssl_cert         => '/etc/ssl/try.puppet.com.crt',
-    ssl_key          => '/etc/ssl/try.puppet.com.key',
+    ssl_port             => '443',
+    ssl                  => true,
+    ssl_cert             => '/etc/ssl/try.puppet.com.crt',
+    ssl_key              => '/etc/ssl/try.puppet.com.key',
+    use_default_location => false,
+    locations            => {
+      '/sandbox/'        => {
+        proxy            => 'http://127.0.0.1:3000',
+        proxy_set_header => [
+          'Upgrade $http_upgrade',
+          'Connection "Upgrade"',
+        ],
+        rewrite_rules     => [
+          '/sandbox(.*) /$1  break'
+        ]
+      },
+      '/' => {
+        www_root => '/var/www'
+      }
+    }
   }
   package { 'puppetclassify':
     ensure   => present,


### PR DESCRIPTION
Ignore the branch name there isn't any new content.  This moves the containers to /sandbox/ and has try.puppet.com as a generic page pointing users to learn.puppet.com