### PR TITLE
Use systemd on unprivileged containers

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,5 +2,5 @@ Module for installing Puppetlabs self-paced training environment
 
 This module sets up an nginx server, docker, web-based terminal, and supporting scripts for the self-paced training exercises.
 
-It should be installed on a Puppet Enterprise Master which has autosigning enabled and filesync disabled.
+It should be installed on a Puppet Enterprise Master running the PE console on an alternate port with autosigning enabled and filesync disabled.
 

--- a/files/selfpaced.rb
+++ b/files/selfpaced.rb
@@ -98,7 +98,7 @@ classify(environment_name, container_name)
 
 
 # Run container
-container = %x{docker run --security-opt seccomp=unconfined --stop-signal=SIGRTMIN+3 --tmpfs /tmp --tmpfs /run --volume #{ENVIRONMENTS}/#{environment_name}:#{PUPPETCODE} --volume /sys/fs/cgroup:/sys/fs/cgroup:ro --hostname #{container_name}.#{USERSUFFIX} --name #{container_name} --add-host=puppet:#{DOCKER_IP} --expose=80 -Ptd #{IMAGE_NAME} /sbin/init}.chomp
+container = %x{docker run --security-opt seccomp=unconfined --stop-signal=SIGRTMIN+3 --tmpfs /tmp --tmpfs /run --security-opt seccomp=unconfied --volume #{ENVIRONMENTS}/#{environment_name}:#{PUPPETCODE} --volume /sys/fs/cgroup:/sys/fs/cgroup:ro --hostname #{container_name}.#{USERSUFFIX} --name #{container_name} --add-host=puppet:#{DOCKER_IP} --expose=80 -Ptd #{IMAGE_NAME} /sbin/init}.chomp
 
 # Set up shutdown timeout
 pid = Process.fork do 

--- a/files/selfpaced.rb
+++ b/files/selfpaced.rb
@@ -33,7 +33,7 @@ AUTH_INFO = OPTIONS['AUTH_INFO'] || {
 
 CLASSIFIER_URL = OPTIONS['CLASSIFIER_URL'] || "http://#{MASTER_HOSTNAME}:4433/classifier-api"
 
-TIMEOUT = OPTIONS['TIMEOUT'] || "300"
+TIMEOUT = OPTIONS['TIMEOUT'] || "900"
 
 def classify(environment, hostname, groups=[''])
   puppetclassify = PuppetClassify.new(CLASSIFIER_URL, AUTH_INFO)
@@ -107,13 +107,18 @@ pid = Process.fork do
 end
 Process.detach(pid)
 
+puts "Running puppet to configure node"
+IO.popen("docker exec -it #{container} puppet agent -t").each_with_index do |line,index|
+  if index % 20 == 0 then
+    printf "."
+  end
+end
+
 puts <<-WELCOME
 ------------------------------------------------------------
 
        Welcome to the Puppetlabs eLearning environment
-           Your session will expire in 5 minutes
-
-              Type `puppet agent -t` to begin
+           Your session will expire in 15 minutes
 
 ------------------------------------------------------------
 WELCOME

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,12 +1,14 @@
 class selfpaced (
   $docroot = selfpaced::params::docroot
 ) inherits selfpaced::params {
-  include docker
-  docker::image {'maci0/systemd':}
+  class { 'docker':
+    extra_parameters => '--default-ulimit nofile=1000000:1000000',
+  }
+  docker::image {'centos:7':}
   docker::image { 'agent':
     docker_dir => '/tmp/agent',
     subscribe => File['/tmp/agent'],
-    require => Docker::Image['maci0/systemd'],
+    require => Docker::Image['centos:7'],
   }
   file { '/tmp/agent':
     ensure => directory,


### PR DESCRIPTION
Systemd can't run by default on docker containers, this adds some cgroup volumes, tmp file systemd, etc. to make this work.  Having systemd running means that services show up as expected, etc.

This also adds some minor improvements to the user experience for try.puppet.com, including running puppet immediately after starting the container.
